### PR TITLE
refactor: move candidateId configuration to API client

### DIFF
--- a/src/clients/crossmint-api.client.ts
+++ b/src/clients/crossmint-api.client.ts
@@ -3,31 +3,32 @@ import type { Position } from '../entities/position.js';
 
 export class CrossmintApiClient {
   private apiUrl: string;
+  private candidateId: string;
 
   constructor() {
     this.apiUrl = process.env.API_URL ?? 'https://challenge.crossmint.com/api';
+    const candidateId = process.env.CANDIDATE_ID;
+    if (!candidateId) throw new Error('Invalid candidate ID');
+    this.candidateId = candidateId;
   }
 
-  async getGoal(candidateId: string): Promise<unknown> {
-    const res = await fetch(`${this.apiUrl}/map/${candidateId}/goal`);
+  async getGoal(): Promise<unknown> {
+    const res = await fetch(`${this.apiUrl}/map/${this.candidateId}/goal`);
     if (!res.ok) throw new Error('Cannot retrieve goal');
     return res.json();
   }
 
-  async postAstralObject(args: {
-    candidateId: string;
-    item: AstralItem & Position;
-  }): Promise<void> {
+  async postAstralObject(item: AstralItem & Position): Promise<void> {
     const headers = new Headers();
     headers.append('Content-Type', 'application/json');
-    const url = `${this.apiUrl}/${this._getResourcePath(args.item)}`;
-    const { name, ...itemFields } = args.item;
+    const url = `${this.apiUrl}/${this._getResourcePath(item)}`;
+    const { name, ...itemFields } = item;
     await fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify({
         ...itemFields,
-        candidateId: args.candidateId,
+        candidateId: this.candidateId,
       }),
     });
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,14 +3,11 @@ import { AstralRepository } from './repositories/astral-repository.js';
 import { GoalsRepository } from './repositories/goals-repository.js';
 
 const main = async () => {
-  const candidateId = process.env.CANDIDATE_ID;
-  if (!candidateId) throw new Error('Invalid candidate ID');
-
   const goalsRepository = new GoalsRepository();
   const astralRepository = new AstralRepository();
 
-  const goal = await goalsRepository.getGoal(candidateId);
-  await astralRepository.setAstralObjects({ candidateId, goal });
+  const goal = await goalsRepository.getGoal();
+  await astralRepository.setAstralObjects(goal);
 };
 
 main();

--- a/src/repositories/astral-repository.ts
+++ b/src/repositories/astral-repository.ts
@@ -10,24 +10,12 @@ export class AstralRepository {
     this.apiClient = new CrossmintApiClient();
   }
 
-  async setAstralObjects(args: {
-    candidateId: string;
-    goal: Goal;
-  }): Promise<void> {
+  async setAstralObjects(goal: Goal): Promise<void> {
     await Promise.all(
       // TODO: backpressure?
-      args.goal
+      goal
         .filter((item) => item.name !== 'space')
-        .map((item) =>
-          this.setAstralObject({ candidateId: args.candidateId, item }),
-        ),
+        .map((item) => this.apiClient.postAstralObject(item)),
     );
-  }
-
-  private async setAstralObject(args: {
-    candidateId: string;
-    item: AstralItem & Position;
-  }): Promise<void> {
-    return this.apiClient.postAstralObject(args);
   }
 }

--- a/src/repositories/goals-repository.ts
+++ b/src/repositories/goals-repository.ts
@@ -13,8 +13,8 @@ export class GoalsRepository {
     this.apiClient = new CrossmintApiClient();
   }
 
-  async getGoal(candidateId: string): Promise<Goal> {
-    const res = await this.apiClient.getGoal(candidateId);
+  async getGoal(): Promise<Goal> {
+    const res = await this.apiClient.getGoal();
     const goal = this._parseGoalResponse(GoalResponseSchema.parse(res));
     return goal;
   }


### PR DESCRIPTION
### Summary
This PR moves the `candidateId` to the relevant class (`CrossmintApiClient`), to favor encapsulation.