### PR TITLE
feature: add backpressure, centralize config

### DIFF
--- a/src/clients/crossmint-api.client.ts
+++ b/src/clients/crossmint-api.client.ts
@@ -1,16 +1,10 @@
 import type { AstralItem } from '../entities/astral-item.js';
 import type { Position } from '../entities/position.js';
+import { configuration } from '../config/configuration.js';
 
 export class CrossmintApiClient {
-  private apiUrl: string;
-  private candidateId: string;
-
-  constructor() {
-    this.apiUrl = process.env.API_URL ?? 'https://challenge.crossmint.com/api';
-    const candidateId = process.env.CANDIDATE_ID;
-    if (!candidateId) throw new Error('Invalid candidate ID');
-    this.candidateId = candidateId;
-  }
+  private readonly apiUrl = configuration.api.url;
+  private readonly candidateId = configuration.api.candidateId;
 
   async getGoal(): Promise<unknown> {
     const res = await fetch(`${this.apiUrl}/map/${this.candidateId}/goal`);

--- a/src/config/configuration.schema.ts
+++ b/src/config/configuration.schema.ts
@@ -1,0 +1,13 @@
+import z from 'zod';
+
+export const ConfigurationSchema = z.object({
+  api: z.object({
+    url: z.url().optional().default('https://challenge.crossmint.com/api'),
+    candidateId: z.string().min(1, 'CANDIDATE_ID must be a non-empty string'),
+  }),
+  concurrency: z.object({
+    maxCalls: z.number().optional().default(10),
+  }),
+});
+
+export type Configuration = z.infer<typeof ConfigurationSchema>;

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,0 +1,11 @@
+import type { Configuration } from './configuration.schema.js';
+
+export const configuration: Configuration = {
+  api: {
+    url: process.env.API_URL!,
+    candidateId: process.env.CANDIDATE_ID!,
+  },
+  concurrency: {
+    maxCalls: 5,
+  },
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,22 @@
 import 'dotenv/config';
+import { configuration } from './config/configuration.js';
 import { AstralRepository } from './repositories/astral-repository.js';
 import { GoalsRepository } from './repositories/goals-repository.js';
+import { ConfigurationSchema } from './config/configuration.schema.js';
 
+/**
+ * Main entry point.
+ * This function validates the app configuration, creates the repository classes,
+ * gets the goal, and draws the objects present in the goal payload.
+ */
 const main = async () => {
+  ConfigurationSchema.parse(configuration);
+
   const goalsRepository = new GoalsRepository();
   const astralRepository = new AstralRepository();
 
   const goal = await goalsRepository.getGoal();
-  await astralRepository.setAstralObjects(goal);
+  await astralRepository.draw(goal);
 };
 
 main();

--- a/src/mappers/astral-mapper.ts
+++ b/src/mappers/astral-mapper.ts
@@ -6,6 +6,10 @@ import {
   type AstralItem,
 } from '../entities/astral-item.js';
 
+/**
+ * Maps a given input string to a instance of a known
+ * {@link AstralItem} subclass, including its specific properties.
+ */
 export class AstralMapper {
   static map(input: string): AstralItem {
     switch (true) {

--- a/src/repositories/goals-repository.ts
+++ b/src/repositories/goals-repository.ts
@@ -13,12 +13,26 @@ export class GoalsRepository {
     this.apiClient = new CrossmintApiClient();
   }
 
+  /**
+   * Gets a Goal map of astral objects.
+   *
+   * @returns a flattened representation of a 2D array, holding both the
+   * astral object data and its position (row + column).
+   */
   async getGoal(): Promise<Goal> {
     const res = await this.apiClient.getGoal();
     const goal = this._parseGoalResponse(GoalResponseSchema.parse(res));
     return goal;
   }
 
+  /**
+   * Parses an unchecked Goal response payload coming from the API client.
+   *
+   * @param goalResponse unchecked payload representing a Goal map.
+   * @returns checked (validated) Goal map: a flattened representation
+   * of a 2D array, holding both the astral object data and its
+   * position (row + column).
+   */
   private _parseGoalResponse(goalResponse: GoalResponse): Goal {
     const { goal } = goalResponse;
     const result: Goal = [];


### PR DESCRIPTION
### Summary
This PR adds a backpressure mechanism to avoid flooding the API when drawing multiple astral objects.

### Relevant changes
- `concurrency.maxCalls` option is added to the configuration, so this parameter limits the maximum parallel calls to the API.
- A new `configuration/configuration.ts` file has been added, in order to centralize the configuration through the service.
- A new schema for this configuration file has been added, verifying the expected configuration exists at startup.